### PR TITLE
Update FacebookProvider.php

### DIFF
--- a/src/FacebookProvider.php
+++ b/src/FacebookProvider.php
@@ -14,6 +14,10 @@ class FacebookProvider extends OAuth2Provider
     protected $fields = [
         'email',
         'name',
+        'first_name',
+        'last_name',
+        'age_range',
+        'timezone',
     ];
 
     protected function getAuthorizeUrl()


### PR DESCRIPTION
Added four extra fields (first_name, last_name, age_range and timezone) from the Facebook [public_profile](https://developers.facebook.com/docs/facebook-login/permissions/v2.4#reference-public_profile) to the fields returned when authenticating against Facebook. These will be available in `$details->raw` and not in the top level of `$details`, as they are not returned by all providers.